### PR TITLE
docs: fix 5.0 schema declaration examples (refs #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ part 'user.freezed.dart';
 part 'user.g.dart';
 
 @freezed
+@firestoreOdm
 class User with _$User {
   const factory User({
     @DocumentIdField() required String id,
@@ -285,14 +286,20 @@ class User with _$User {
 ### 2. Define Your Schema
 ```dart
 // lib/schema.dart
-import 'package:firestore_odm_annotation/firestore_odm_annotation.dart';
+import 'package:firestore_odm/firestore_odm.dart';
 import 'models/user.dart';
 
-part 'schema.odm.dart';
+part 'schema.g.dart'; // combined generated part (ODM + json_serializable)
+
+/// The schema class is declared by hand (ADR-0002) so the schema variable's
+/// type is resolvable before code generation.
+class AppSchema extends FirestoreSchema {
+  const AppSchema();
+}
 
 @Schema()
 @Collection<User>("users")
-final appSchema = _$AppSchema;
+const appSchema = AppSchema();
 ```
 
 ### 3. Generate Code

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -54,6 +54,8 @@ Create your data model. We recommend using packages like `freezed` for robust, i
 
 Crucially, you must tell the ODM which field holds the document's ID by annotating it with `@DocumentIdField()`. For more details, see the [Document ID Handling](/guide/document-id.html) guide.
 
+Every model that appears in a `@Collection` must also carry the `@firestoreOdm` annotation; that is what makes the generator emit the model's converters and patch/filter/orderBy selectors.
+
 ```dart
 // lib/models/user.dart
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -64,6 +66,7 @@ part 'user.freezed.dart';
 part 'user.g.dart';
 
 @freezed
+@firestoreOdm
 class User with _$User {
   const factory User({
     // This field is automatically populated with the document ID

--- a/docs/guide/migration-guide.md
+++ b/docs/guide/migration-guide.md
@@ -570,11 +570,15 @@ List<Map<String, dynamic>> posts = postsSnapshot.docs
 ### After (Type-Safe Subcollection Access)
 ```dart
 // Schema definition with subcollections
+class AppSchema extends FirestoreSchema {
+  const AppSchema();
+}
+
 @Schema()
 @Collection<User>("users")
 @Collection<Post>("users/*/posts")
 @Collection<Comment>("users/*/posts/*/comments")
-final appSchema = _$AppSchema;
+const appSchema = AppSchema();
 
 // Type-safe subcollection access (path-derived accessors, ADR-0002)
 final userPosts = db.usersPosts('user123');

--- a/docs/guide/multiple-instances.md
+++ b/docs/guide/multiple-instances.md
@@ -16,19 +16,27 @@ Create different schema definitions in your application.
 
 ```dart
 // lib/schemas/admin_schema.dart
+class AdminSchema extends FirestoreSchema {
+  const AdminSchema();
+}
+
 @Schema()
 @Collection<User>("users")
 @Collection<AuditLog>("audit_logs")
-final adminSchema = _$AdminSchema;
+const adminSchema = AdminSchema();
 
 // lib/schemas/user_schema.dart
+class UserSchema extends FirestoreSchema {
+  const UserSchema();
+}
+
 @Schema()
 @Collection<User>("users")
 @Collection<Post>("posts")
-final userSchema = _$UserSchema;
+const userSchema = UserSchema();
 ```
 
-After running the build runner, this will generate `adminSchema.odm.dart` and `userSchema.odm.dart`.
+After running the build runner, the generated extensions land in `admin_schema.g.dart` and `user_schema.g.dart` (each schema file declares its part).
 
 ### 2. Create Separate ODM Instances
 

--- a/docs/guide/schema-definition.md
+++ b/docs/guide/schema-definition.md
@@ -4,20 +4,26 @@ The foundation of the ODM is the **Schema**. The schema is a central definition 
 
 ## How to Define a Schema
 
-You create a single schema file that defines all your collections. You do this by creating a top-level variable and annotating it with `@Schema()` and one or more `@Collection<Model>(collectionPath)` annotations.
+You create a single schema file that defines all your collections. You do this by declaring the schema class by hand (so the schema variable's type is resolvable before code generation) and annotating a top-level variable of that type with `@Schema()` and one or more `@Collection<Model>(collectionPath)` annotations.
 
 ```dart
 // lib/schema.dart
-import 'package:firestore_odm_annotation/firestore_odm_annotation.dart';
+import 'package:firestore_odm/firestore_odm.dart';
 import 'models/user.dart';
 import 'models/post.dart';
 
-part 'schema.odm.dart';
+part 'schema.g.dart'; // combined generated part (ODM + json_serializable)
+
+/// The schema class is declared by hand (ADR-0002) so the schema variable's
+/// type is resolvable before code generation.
+class FirestoreDatabase extends FirestoreSchema {
+  const FirestoreDatabase();
+}
 
 @Schema()
 @Collection<User>("users")
 @Collection<Post>("posts")
-final firestoreDatabase = _$FirestoreDatabase; // The variable name can be anything
+const firestoreDatabase = FirestoreDatabase(); // The variable name can be anything
 ```
 
 After defining your schema and models, run the build runner:

--- a/docs/guide/subcollections.md
+++ b/docs/guide/subcollections.md
@@ -15,12 +15,16 @@ In this example, we define a `posts` subcollection that lives under each `user` 
 ```dart
 // lib/schema.dart
 
+class AppSchema extends FirestoreSchema {
+  const AppSchema();
+}
+
 @Schema()
 // Root-level collection
 @Collection<User>("users")
 // Subcollection of users. The '*' is a wildcard for the user ID.
 @Collection<Post>("users/*/posts")
-final appSchema = _$AppSchema;
+const appSchema = AppSchema();
 ```
 
 The generator will automatically detect this relationship and create the necessary accessors.


### PR DESCRIPTION
Fixes the documentation defect reported in #42: the getting-started schema
example (and every other schema example on the 5.0 line) still used the 4.x
form, which the 5.0 builder rejects before generating anything:

```
E firestore_odm_builder on lib/schema.dart:
  @Schema variable must have an interface type, found InvalidType
  9 | final appSchema = _$AppSchema;
    |       ^^^^^^^^^
  Failed to build with build_runner/aot; wrote 0 outputs.
```

## What changed
- `README.md`, `docs/guide/schema-definition.md`, `docs/guide/multiple-instances.md`,
  `docs/guide/subcollections.md`, `docs/guide/migration-guide.md`: declare the schema
  class by hand (`class AppSchema extends FirestoreSchema`), use
  `const appSchema = AppSchema();`, and declare the combined generated part
  (`part 'schema.g.dart';`).
- `README.md`, `docs/guide/getting-started.md`: annotate the model example with
  `@firestoreOdm`. The generator only emits a model's converters, patch builder and
  selectors when the class carries that annotation; without it the generated schema
  extension references undefined symbols (`UserToJson`, `UserPatchBuilder`, ...).

## Evidence
Scratch Flutter package, `firestore_odm: 5.0.0` and `firestore_odm_builder: 5.0.0`
from pub.dev, Flutter 3.44.2 / Dart 3.12.2, `dart run build_runner build --delete-conflicting-outputs`:

- documented 4.x form -> the error above, `wrote 0 outputs`;
- corrected form (schema + `@firestoreOdm`) -> `Built with build_runner/aot in 34s; wrote 4 outputs`
  and `flutter analyze` -> `No issues found!`.

Cross-check of the generator contract: `packages/firestore_odm_builder/lib/src/schema_generator.dart`
requires an `InterfaceType` schema variable and `model_builder_generator.dart` filters model
classes by the `FirestoreOdm` annotation; `apps/flutter_example/lib/test_schema.dart` uses
exactly the corrected form.

## Remaining / out of scope here
- This branch is the released 5.0 line, so the fix reaches pub.dev with the next release
  from it; the already-published 5.0.0 README cannot be edited in place.
- `main` still carries the 4.x docs and needs its own fix (`part 'schema.odm.dart'` ->
  `part 'schema.g.dart'`, keeping the `_$AppSchema` form: the hand-declared class collides
  with the class the 4.x generator emits). The GitHub Pages site builds from `main`.
- Other guide pages (data-modeling, document-id, migration-guide examples) also omit
  `@firestoreOdm`; only the getting-started surfaces are corrected here.
- The same getting-started page still shows `odm.users.where((_) => _.name(isEqualTo: 'Jane Smith'))`;
  `_` cannot be referenced as a value in current Dart (analyzer: `Undefined name '_'`); the 5.0 form
  is `($) => $.name(isEqualTo: ...)`. Left untouched here to keep this diff on the reported defect.

Agent: Codex sub-agent `fix_firestore_odm_42` (2026-09-10), executed by helper agent
`firestore_odm_42_publisher` at the author's instruction.

